### PR TITLE
use mqtt client to deal with subscriptions (it supports wildcards), ...

### DIFF
--- a/modules/mqtt-client/src/mqtt_client.cpp
+++ b/modules/mqtt-client/src/mqtt_client.cpp
@@ -331,35 +331,40 @@ static void* mqtt_client_new(t_symbol* s, COMP_T_ARGC argc, t_atom* argv)
         int size = (floats.empty() ? 1 : floats.size()) + topicStrings.size();
 
         // set topic list
-        t_atom a[size];
-        for (size_t i=0; i<topicStrings.size(); i++) {
-            a[i].a_type = COMP_SYMBOL;
-            a[i].a_w.COMP_W_SYMBOL = gensym(topicStrings[i].c_str());
-        }
+        t_atom *a = new t_atom[size];
+        if (a)
+        {
+            for (size_t i=0; i<topicStrings.size(); i++) {
+                a[i].a_type = COMP_SYMBOL;
+                a[i].a_w.COMP_W_SYMBOL = gensym(topicStrings[i].c_str());
+            }
 
-        if (isNumber) {
-            // type check
-            if ((floatValue - int(floatValue)) == 0) {
-                a[size-1].a_type = COMP_LONG;
-                a[size-1].a_w.COMP_W_LONG = intValue;
+            if (isNumber) {
+                // type check
+                if ((floatValue - int(floatValue)) == 0) {
+                    a[size-1].a_type = COMP_LONG;
+                    a[size-1].a_w.COMP_W_LONG = intValue;
+                    outlet_anything(x->out1, gensym("list"), size, a);
+                } else {
+                    a[size-1].a_type = A_FLOAT;
+                    a[size-1].a_w.w_float = floatValue;
+                    outlet_anything(x->out1, gensym("list"), size, a);
+                }
+            } else if (!floats.empty()) {
+                // output list
+                for (size_t i=0; i<floats.size(); i++) {
+                    a[topicStrings.size() + i].a_type = A_FLOAT;
+                    a[topicStrings.size() + i].a_w.w_float = floats[i];
+                }
                 outlet_anything(x->out1, gensym("list"), size, a);
             } else {
-                a[size-1].a_type = A_FLOAT;
-                a[size-1].a_w.w_float = floatValue;
+                // just output that string
+                a[size-1].a_type = COMP_SYMBOL;
+                a[size-1].a_w.COMP_W_SYMBOL = gensym(value.c_str());
                 outlet_anything(x->out1, gensym("list"), size, a);
             }
-        } else if (!floats.empty()) {
-            // output list
-            for (size_t i=0; i<floats.size(); i++) {
-                a[topicStrings.size() + i].a_type = A_FLOAT;
-                a[topicStrings.size() + i].a_w.w_float = floats[i];
-            }
-            outlet_anything(x->out1, gensym("list"), size, a);
-        } else {
-            // just output that string
-            a[size-1].a_type = COMP_SYMBOL;
-            a[size-1].a_w.COMP_W_SYMBOL = gensym(value.c_str());
-            outlet_anything(x->out1, gensym("list"), size, a);
+
+            delete[] a;
         }
     });
 


### PR DESCRIPTION
split topic to list
add support for number-lists (space-separator)

Hi.
This PR is a rework of how the subscription works, it relies on PAHO to deal with wildcards. This branch also contains the changes i made on branch `allow_receive_strings_with_leading_number` to deal with number-prefixed strings. furthermore this branch splits a list of numbers separated by a space into a float-list, thought this is handy - no need to split a string in Pd with some additional dependency.

Allowing to subscribe with wildcards make it necessary to deal with topics differently. It now separates the topic into a list so we can route it in Pd.

It changes the way messages are received, but i hope you find this useful and merge it into the main-branch.